### PR TITLE
Add flexible lint rules

### DIFF
--- a/lint-rules.json
+++ b/lint-rules.json
@@ -1,0 +1,11 @@
+{
+  "QuotationMarks": {
+    "PreferredOpen": "«",
+    "PreferredClose": "»",
+    "Forbidden": ["\"", "'"]
+  },
+  "Hyphen": {
+    "WrongSymbol": "-",
+    "Replacement": "—"
+  }
+}

--- a/tex-lint/Models/LintRules.cs
+++ b/tex-lint/Models/LintRules.cs
@@ -1,0 +1,20 @@
+namespace TexLint.Models;
+
+public class LintRules
+{
+    public QuotationMarkRule QuotationMarks { get; set; } = new();
+    public HyphenRule Hyphen { get; set; } = new();
+}
+
+public class QuotationMarkRule
+{
+    public string PreferredOpen { get; set; } = "«";
+    public string PreferredClose { get; set; } = "»";
+    public string[] Forbidden { get; set; } = System.Array.Empty<string>();
+}
+
+public class HyphenRule
+{
+    public string WrongSymbol { get; set; } = "-";
+    public string Replacement { get; set; } = "—";
+}

--- a/tex-lint/TestFunctionClasses/TestHyphenInsteadOfDash.cs
+++ b/tex-lint/TestFunctionClasses/TestHyphenInsteadOfDash.cs
@@ -8,10 +8,13 @@ namespace TexLint.TestFunctionClasses;
 
 public class TestHyphenInsteadOfDash : TestFunction
 {
+    private readonly char _wrongHyphen;
   public TestHyphenInsteadOfDash()
     {
         var commands = JsonSerializer.Deserialize<List<ParseInfo>>(new StreamReader(TestUtilities.PathToCommandsJson).ReadToEnd());
         var environments = JsonSerializer.Deserialize<List<ParseInfo>>(new StreamReader(TestUtilities.PathToEnvironmentJson).ReadToEnd());
+        var rules = JsonSerializer.Deserialize<LintRules>(new StreamReader(TestUtilities.PathToLintRulesJson).ReadToEnd());
+        _wrongHyphen = string.IsNullOrEmpty(rules?.Hyphen.WrongSymbol) ? '-' : rules.Hyphen.WrongSymbol[0];
 
         List<string> commandsNamesWherePhraseArgOrParam = new();
         foreach (var command in commands)
@@ -158,7 +161,7 @@ public class TestHyphenInsteadOfDash : TestFunction
     {
         for (var i = 0; i < text.Length; i++)
         {
-            if (text[i] != '-')
+            if (text[i] != _wrongHyphen)
                 continue;
             
             bool left = true;

--- a/tex-lint/TestFunctionClasses/TestQuotationMarks.cs
+++ b/tex-lint/TestFunctionClasses/TestQuotationMarks.cs
@@ -6,10 +6,13 @@ namespace TexLint.TestFunctionClasses;
 
 public class TestQuotationMarks : TestFunction
 {
+    private readonly char[] _invalidQuotes;
     public TestQuotationMarks()
     {
         var commands = JsonSerializer.Deserialize<List<ParseInfo>>(new StreamReader(TestUtilities.PathToCommandsJson).ReadToEnd());
         var environments = JsonSerializer.Deserialize<List<ParseInfo>>(new StreamReader(TestUtilities.PathToEnvironmentJson).ReadToEnd());
+        var rules = JsonSerializer.Deserialize<LintRules>(new StreamReader(TestUtilities.PathToLintRulesJson).ReadToEnd());
+        _invalidQuotes = rules?.QuotationMarks.Forbidden.Select(s => s[0]).ToArray() ?? Array.Empty<char>();
 
         List<string> commandsNamesWherePhraseArgOrParam = new();
         foreach (var command in commands)
@@ -97,9 +100,10 @@ public class TestQuotationMarks : TestFunction
     {
         for (var i = 0; i < text.Length; i++)
         {
-            if (text[i] == '\"' || text[i] == '\'')
+            foreach (var ch in _invalidQuotes)
             {
-                return i;
+                if (text[i] == ch)
+                    return i;
             }
         }
 

--- a/tex-lint/TestFunctionClasses/TestUtilities.cs
+++ b/tex-lint/TestFunctionClasses/TestUtilities.cs
@@ -12,6 +12,7 @@ public static class TestUtilities
 {
     public static string PathToCommandsJson = "commands.json";
     public static string PathToEnvironmentJson = "environments.json";
+    public static string PathToLintRulesJson = "lint-rules.json";
     public static List<Command> FoundsCommands { get; set; }
     public static List<Command> FoundsCommandsWithLstlisting { get; set; }
     public static string StartDirectory { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- introduce lint-rules.json for customization
- provide C# model classes for lint rules
- load lint rules in quotation and hyphen tests
- reference new config path in utilities

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840083c4840832b9bdd8a2ee03b0d02